### PR TITLE
Initial port from lrtable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+target/
+*.swp
+Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: rust
+rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "cfgrammar"
+version = "0.1.0"
+authors = ["Laurence Tratt <http://tratt.net/laurie/>"]
+
+[lib]
+name = "cfgrammar"
+path = "src/lib/mod.rs"
+
+[dependencies]
+getopts = "0.2.14"
+lazy_static = "0.2.2"
+regex = "0.1.80"
+macro-attr = "0.2.0"
+newtype_derive = "0.1.6"

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,0 +1,79 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
+// copy of this software, associated documentation and/or data (collectively the "Software"), free
+// of charge and under any and all copyright rights in the Software, and any and all patent rights
+// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
+// below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software is contributed
+// by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create derivative works
+// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
+// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
+// foregoing rights on either these or other terms.
+//
+// This license is subject to the following condition: The above copyright notice and either this
+// complete permission notice or at a minimum a reference to the UPL must be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#[macro_use] extern crate lazy_static;
+#[macro_use] extern crate macro_attr;
+#[macro_use] extern crate newtype_derive;
+
+pub mod yacc;
+pub use yacc::YaccGrammar;
+
+// A note on the terminology we use, since there's no universal standard (and EBNF, which is
+// perhaps the closest we've got, uses terminology that now seems partially anachronistic):
+//   A rule is a mapping from a nonterminal name to 1 or more productions (the latter of which is
+//     often called 'alternatives').
+//   A symbol is either a nonterminal or a terminal.
+//   A production is a (possibly empty) ordered sequence of symbols.
+//
+// Every nonterminal has a corresponding rule; however, terminals are not required to appear in any
+// production (such terminals can be used to catch error conditions).
+//
+// Internally, we assume that a grammar's start rule has a single production. Since we manually
+// create the start rule ourselves (without relying on user input), this is a safe assumption.
+
+macro_attr! {
+    /// A type specifically for nonterminal indices.
+    #[derive(Clone, Copy, Debug, Eq, Hash, NewtypeFrom!, PartialEq)]
+    pub struct NTIdx(usize);
+}
+macro_attr! {
+    /// A type specifically for production indices (e.g. a rule "E::=A|B" would
+    /// have two productions for the single rule E).
+    #[derive(Clone, Copy, Debug, Eq, Hash, NewtypeFrom!, PartialEq, PartialOrd)]
+    pub struct PIdx(usize);
+}
+macro_attr! {
+    /// A type specifically for symbol indices (within a production).
+    #[derive(Clone, Copy, Debug, Eq, Hash, NewtypeFrom!, PartialEq, PartialOrd)]
+    pub struct SIdx(usize);
+}
+macro_attr! {
+    /// A type specifically for token indices.
+    #[derive(Clone, Copy, Debug, Eq, Hash, NewtypeFrom!, PartialEq)]
+    pub struct TIdx(usize);
+}
+
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub enum Symbol {
+    Nonterminal(NTIdx),
+    Terminal(TIdx)
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -77,3 +77,14 @@ pub enum Symbol {
     Nonterminal(NTIdx),
     Terminal(TIdx)
 }
+
+pub trait Grammar {
+    /// How many terminals does this grammar have?
+    fn terms_len(&self) -> usize;
+    /// How many productions does this grammar have?
+    fn prods_len(&self) -> usize;
+    /// How many nonterminals does this grammar have?
+    fn nonterms_len(&self) -> usize;
+    /// What is the index of the start rule?
+    fn start_rule_idx(&self) -> NTIdx;
+}

--- a/src/lib/yacc/ast.rs
+++ b/src/lib/yacc/ast.rs
@@ -1,0 +1,335 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
+// copy of this software, associated documentation and/or data (collectively the "Software"), free
+// of charge and under any and all copyright rights in the Software, and any and all patent rights
+// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
+// below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software is contributed
+// by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create derivative works
+// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
+// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
+// foregoing rights on either these or other terms.
+//
+// This license is subject to the following condition: The above copyright notice and either this
+// complete permission notice or at a minimum a reference to the UPL must be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+use yacc::Precedence;
+
+pub struct GrammarAST {
+    pub start: Option<String>,
+    pub rules: HashMap<String, Rule>,
+    pub tokens: HashSet<String>,
+    pub precs: HashMap<String, Precedence>
+}
+
+#[derive(Debug)]
+pub struct Rule {
+    pub name: String,
+    pub productions: Vec<Production>
+}
+
+#[derive(Debug)]
+pub struct Production {
+    pub symbols: Vec<Symbol>,
+    pub precedence: Option<String>
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub enum Symbol {
+    Nonterminal(String),
+    Terminal(String)
+}
+
+/// The various different possible grammar validation errors.
+#[derive(Debug)]
+pub enum GrammarValidationErrorKind {
+    NoStartRule,
+    InvalidStartRule,
+    UnknownRuleRef,
+    UnknownToken,
+    NoPrecForToken
+}
+
+/// `GrammarAST` validation errors return an instance of this struct.
+#[derive(Debug)]
+pub struct GrammarValidationError {
+    pub kind: GrammarValidationErrorKind,
+    pub sym: Option<Symbol>
+}
+
+impl fmt::Display for GrammarValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.kind {
+            GrammarValidationErrorKind::NoStartRule => {
+                write!(f, "No start rule specified")
+            },
+            GrammarValidationErrorKind::InvalidStartRule => {
+                write!(f, "Start rule '{}' does not appear in grammar", self.sym.as_ref().unwrap())
+            },
+            GrammarValidationErrorKind::UnknownRuleRef => {
+                write!(f, "Unknown reference to rule '{}'", self.sym.as_ref().unwrap())
+            },
+            GrammarValidationErrorKind::UnknownToken => {
+                write!(f, "Unknown token '{}'", self.sym.as_ref().unwrap())
+            },
+            GrammarValidationErrorKind::NoPrecForToken => {
+                write!(f, "Token '{}' used in %prec has no precedence attached", self.sym.as_ref().unwrap())
+            }
+        }
+    }
+}
+
+impl fmt::Display for Symbol {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Symbol::Nonterminal(ref s) => write!(f, "{}", s),
+            Symbol::Terminal(ref s)    => write!(f, "{}", s)
+        }
+    }
+}
+
+impl GrammarAST {
+    pub fn new() -> GrammarAST {
+        GrammarAST {
+            start:   None,
+            rules:   HashMap::new(),
+            tokens:  HashSet::new(),
+            precs:   HashMap::new(),
+        }
+    }
+
+    pub fn add_prod(&mut self, key: String, syms: Vec<Symbol>, prec: Option<String>) {
+        let rule = self.rules.entry(key.clone()).or_insert_with(|| Rule::new(key));
+        rule.add_prod(syms, prec);
+    }
+
+    pub fn get_rule(&self, key: &str) -> Option<&Rule>{
+        self.rules.get(key)
+    }
+
+    pub fn has_token(&self, s: &str) -> bool {
+        self.tokens.contains(s)
+    }
+
+    /// Perform basic validation on the grammar, namely:
+    ///   1) The start rule references a rule in the grammar
+    ///   2) Every nonterminal reference references a rule in the grammar
+    ///   3) Every terminal reference references a declared token
+    ///   4) If a production has a precedence terminal, then it references a declared token
+    /// If the validation succeeds, None is returned.
+    pub fn validate(&self) -> Result<(), GrammarValidationError> {
+        match self.start {
+            None => return Err(GrammarValidationError{kind: GrammarValidationErrorKind::NoStartRule, sym: None}),
+            Some(ref s) => {
+                if !self.rules.contains_key(s) {
+                    return Err(GrammarValidationError{kind: GrammarValidationErrorKind::InvalidStartRule,
+                                               sym: Some(Symbol::Nonterminal(s.clone()))});
+                }
+            }
+        }
+        for rule in self.rules.values() {
+            for prod in &rule.productions {
+                if let Some(ref n) = prod.precedence {
+                    if !self.tokens.contains(n) {
+                        return Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownToken,
+                            sym: Some(Symbol::Terminal(n.clone()))});
+                    }
+                    if !self.precs.contains_key(n) {
+                        return Err(GrammarValidationError{kind: GrammarValidationErrorKind::NoPrecForToken,
+                            sym: Some(Symbol::Terminal(n.clone()))});
+                    }
+                }
+                for sym in &prod.symbols {
+                    match *sym {
+                        Symbol::Nonterminal(ref name) => {
+                            if !self.rules.contains_key(name) {
+                                return Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownRuleRef,
+                                    sym: Some(sym.clone())});
+                            }
+                        }
+                        Symbol::Terminal(ref name) => {
+                            if !self.tokens.contains(name) {
+                                return Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownToken,
+                                    sym: Some(sym.clone())});
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl PartialEq for Production {
+    fn eq(&self, other: &Production) -> bool {
+        self.symbols == other.symbols
+    }
+}
+
+impl Rule {
+    pub fn new(name: String) -> Rule {
+        Rule {name: name, productions: vec![]}
+    }
+
+    pub fn add_prod(&mut self, syms: Vec<Symbol>, prec: Option<String>) {
+        self.productions.push(Production{symbols: syms, precedence: prec});
+    }
+}
+
+impl PartialEq for Rule {
+    fn eq(&self, other: &Rule) -> bool {
+        self.name == other.name && self.productions == other.productions
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{GrammarAST, GrammarValidationError, GrammarValidationErrorKind, Symbol};
+    use yacc::{AssocKind, Precedence};
+
+    fn nonterminal(n: &str) -> Symbol {
+        Symbol::Nonterminal(n.to_string())
+    }
+
+    fn terminal(n: &str) -> Symbol {
+        Symbol::Terminal(n.to_string())
+    }
+
+    #[test]
+    fn test_empty_grammar(){
+        let grm = GrammarAST::new();
+        match grm.validate() {
+            Err(GrammarValidationError{kind: GrammarValidationErrorKind::NoStartRule, ..}) => (),
+            _ => panic!("Validation error")
+        }
+    }
+
+    #[test]
+    fn test_invalid_start_rule(){
+        let mut grm = GrammarAST::new();
+        grm.start = Some("A".to_string());
+        grm.add_prod("B".to_string(), vec!(), None);
+        match grm.validate() {
+            Err(GrammarValidationError{kind: GrammarValidationErrorKind::InvalidStartRule, ..}) => (),
+            _ => panic!("Validation error")
+        }
+    }
+
+    #[test]
+    fn test_valid_start_rule(){
+        let mut grm = GrammarAST::new();
+        grm.start = Some("A".to_string());
+        grm.add_prod("A".to_string(), vec!(), None);
+        assert!(grm.validate().is_ok());
+    }
+
+    #[test]
+    fn test_valid_nonterminal_ref(){
+        let mut grm = GrammarAST::new();
+        grm.start = Some("A".to_string());
+        grm.add_prod("A".to_string(), vec!(nonterminal("B")), None);
+        grm.add_prod("B".to_string(), vec!(), None);
+        assert!(grm.validate().is_ok());
+    }
+
+    #[test]
+    fn test_invalid_nonterminal_ref(){
+        let mut grm = GrammarAST::new();
+        grm.start = Some("A".to_string());
+        grm.add_prod("A".to_string(), vec!(nonterminal("B")), None);
+        match grm.validate() {
+            Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownRuleRef, ..}) => (),
+            _ => panic!("Validation error")
+        }
+    }
+
+    #[test]
+    fn test_valid_terminal_ref(){
+        let mut grm = GrammarAST::new();
+        grm.tokens.insert("b".to_string());
+        grm.start = Some("A".to_string());
+        grm.add_prod("A".to_string(), vec!(terminal("b")), None);
+        assert!(grm.validate().is_ok());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_valid_token_ref(){
+        // for now we won't support the YACC feature that allows
+        // to redefine nonterminals as tokens by adding them to '%token'
+        let mut grm = GrammarAST::new();
+        grm.tokens.insert("b".to_string());
+        grm.start = Some("A".to_string());
+        grm.add_prod("A".to_string(), vec!(nonterminal("b")), None);
+        assert!(grm.validate().is_ok());
+    }
+
+    #[test]
+    fn test_invalid_terminal_ref(){
+        let mut grm = GrammarAST::new();
+        grm.start = Some("A".to_string());
+        grm.add_prod("A".to_string(), vec!(terminal("b")), None);
+        match grm.validate() {
+            Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownToken, ..}) => (),
+            _ => panic!("Validation error")
+        }
+    }
+
+    #[test]
+    fn test_invalid_nonterminal_forgotten_token(){
+        let mut grm = GrammarAST::new();
+        grm.start = Some("A".to_string());
+        grm.add_prod("A".to_string(), vec!(nonterminal("b"), terminal("b")), None);
+        match grm.validate() {
+            Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownRuleRef, ..}) => (),
+            _ => panic!("Validation error")
+        }
+    }
+
+    #[test]
+    fn test_precedence_override(){
+        let mut grm = GrammarAST::new();
+        grm.precs.insert("b".to_string(), Precedence{level: 1, kind: AssocKind::Left});
+        grm.start = Some("A".to_string());
+        grm.tokens.insert("b".to_string());
+        grm.add_prod("A".to_string(), vec!(terminal("b")), Some("b".to_string()));
+        assert!(grm.validate().is_ok());
+    }
+
+    #[test]
+    fn test_invalid_precedence_override(){
+        let mut grm = GrammarAST::new();
+        grm.start = Some("A".to_string());
+        grm.add_prod("A".to_string(), vec!(terminal("b")), Some("b".to_string()));
+        match grm.validate() {
+            Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownToken, ..}) => (),
+            _ => panic!("Validation error")
+        }
+        grm.tokens.insert("b".to_string());
+        match grm.validate() {
+            Err(GrammarValidationError{kind: GrammarValidationErrorKind::NoPrecForToken, ..}) => (),
+            _ => panic!("Validation error")
+        }
+    }
+}

--- a/src/lib/yacc/mod.rs
+++ b/src/lib/yacc/mod.rs
@@ -1,0 +1,409 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
+// copy of this software, associated documentation and/or data (collectively the "Software"), free
+// of charge and under any and all copyright rights in the Software, and any and all patent rights
+// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
+// below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software is contributed
+// by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create derivative works
+// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
+// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
+// foregoing rights on either these or other terms.
+//
+// This license is subject to the following condition: The above copyright notice and either this
+// complete permission notice or at a minimum a reference to the UPL must be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use std::collections::HashMap;
+
+use super::{NTIdx, PIdx, SIdx, Symbol, TIdx};
+
+mod ast;
+mod parser;
+
+const START_NONTERM: &'static str = "^";
+const END_TERM     : &'static str = "$";
+
+pub type PrecedenceLevel = u64;
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Precedence {
+    pub level: PrecedenceLevel,
+    pub kind:  AssocKind
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum AssocKind {
+    Left,
+    Right,
+    Nonassoc
+}
+
+pub struct YaccGrammar {
+    /// How many nonterminals does this grammar have?
+    pub nonterms_len: usize,
+    /// A mapping from NTIdx -> String.
+    pub nonterminal_names: Vec<String>,
+    /// A mapping from TIdx -> String.
+    pub terminal_names: Vec<String>,
+    /// A mapping from TIdx -> Option<Precedence>
+    pub terminal_precs: Vec<Option<Precedence>>,
+    /// How many terminals does this grammar have?
+    pub terms_len: usize,
+    /// The offset of the EOF terminal.
+    pub end_term: TIdx,
+    /// How many productions does this grammar have?
+    pub prods_len: usize,
+    /// Which production is the sole production of the start rule?
+    pub start_prod: PIdx,
+    /// A list of all productions.
+    pub prods: Vec<Vec<Symbol>>,
+    /// A mapping from rules to their productions. Note that 1) the order of rules is identical to
+    /// that of `nonterminal_names' 2) every rule will have at least 1 production 3) productions
+    /// are not necessarily stored sequentially.
+    pub rules_prods: Vec<Vec<PIdx>>,
+    /// A mapping from productions to their corresponding rule indexes.
+    pub prods_rules: Vec<NTIdx>,
+    /// The precedence of each production.
+    pub prod_precs: Vec<Option<Precedence>>
+}
+
+
+impl YaccGrammar {
+    /// Translate a `GrammarAST` into a `YaccGrammar`. This function is akin to the part a traditional
+    /// compiler that takes in an AST and converts it into a binary.
+    ///
+    /// As we're compiling the `GrammarAST` into a `Grammar` we do two extra things:
+    ///   1) Add a new start rule (which we'll refer to as "^", though the actual name is a fresh name
+    ///      that is guaranteed to be unique) that references the user defined start rule.
+    ///   2) Add a new end terminal (which we'll refer to as "$", though the actual name is a fresh
+    ///      name that is guaranteed to be unique).
+    /// So, if the user's start rule is S, we add a nonterminal with a single production `^ : S '$';`.
+    pub fn new(ast: &ast::GrammarAST) -> YaccGrammar {
+        // The user is expected to have called validate before calling this function.
+        debug_assert!(ast.validate().is_ok());
+
+        // First of all generate guaranteed unique start nonterm and end term names. We simply keep
+        // making the string longer until we've hit something unique (at the very worst, this will
+        // require looping for as many times as there are nonterminals / terminals).
+
+        let mut start_nonterm = START_NONTERM.to_string();
+        while ast.rules.get(&start_nonterm).is_some() {
+            start_nonterm = start_nonterm + START_NONTERM;
+        }
+
+        let mut end_term = END_TERM.to_string();
+        while ast.tokens.iter().any(|x| x == &end_term) {
+            end_term = end_term + END_TERM;
+        }
+
+        let mut nonterm_names: Vec<String> = Vec::with_capacity(ast.rules.len() + 1);
+        nonterm_names.push(start_nonterm.clone());
+        for k in ast.rules.keys() { nonterm_names.push(k.clone()); }
+        nonterm_names.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+        let mut rules_prods:Vec<Vec<PIdx>> = Vec::with_capacity(nonterm_names.len());
+        let mut nonterm_map = HashMap::<String, NTIdx>::new();
+        for (i, v) in nonterm_names.iter().enumerate() {
+            rules_prods.push(Vec::new());
+            nonterm_map.insert(v.clone(), NTIdx(i));
+        }
+        let mut term_names: Vec<String> = Vec::with_capacity(ast.tokens.len() + 1);
+        let mut term_precs: Vec<Option<Precedence>> = Vec::with_capacity(ast.tokens.len() + 1);
+        term_names.push(end_term.clone());
+        term_precs.push(None);
+        for k in &ast.tokens {
+            term_names.push(k.clone());
+            term_precs.push(ast.precs.get(k).cloned());
+        }
+        let mut terminal_map = HashMap::<String, TIdx>::new();
+        for (i, v) in term_names.iter().enumerate() {
+            terminal_map.insert(v.clone(), TIdx(i));
+        }
+
+        let mut prods                               = Vec::new();
+        let mut prod_precs: Vec<Option<Precedence>> = Vec::new();
+        let mut prods_rules = Vec::new();
+        for astrulename in &nonterm_names {
+            let rule_idx = nonterm_map[astrulename];
+            if astrulename == &start_nonterm {
+                rules_prods.get_mut(usize::from(nonterm_map[&start_nonterm])).unwrap().push(prods.len().into());
+                let start_prod = vec![Symbol::Nonterminal(nonterm_map[ast.start.as_ref().unwrap()])];
+                prods.push(start_prod);
+                prod_precs.push(None);
+                prods_rules.push(rule_idx);
+                continue;
+            }
+            let astrule = &ast.rules[astrulename];
+            let mut rule = &mut rules_prods[usize::from(rule_idx)];
+            for astprod in &astrule.productions {
+                let mut prod = Vec::with_capacity(astprod.symbols.len());
+                for astsym in &astprod.symbols {
+                    let sym = match *astsym {
+                        ast::Symbol::Nonterminal(ref n) =>
+                            Symbol::Nonterminal(nonterm_map[n]),
+                        ast::Symbol::Terminal(ref n) =>
+                            Symbol::Terminal(terminal_map[n])
+                    };
+                    prod.push(sym);
+                }
+                let mut prec = None;
+                if let Some(ref n) = astprod.precedence {
+                    prec = Some(ast.precs[n]);
+                } else {
+                    for astsym in astprod.symbols.iter().rev() {
+                        if let ast::Symbol::Terminal(ref n) = *astsym {
+                            if let Some(p) = ast.precs.get(n) {
+                                prec = Some(*p);
+                            }
+                            break;
+                        }
+                    }
+                }
+                (*rule).push(prods.len().into());
+                prods.push(prod);
+                prod_precs.push(prec);
+                prods_rules.push(rule_idx);
+            }
+        }
+
+        YaccGrammar{
+            nonterms_len:      nonterm_names.len(),
+            nonterminal_names: nonterm_names,
+            terms_len:         term_names.len(),
+            end_term:          terminal_map[&end_term],
+            terminal_names:    term_names,
+            terminal_precs:    term_precs,
+            prods_len:         prods.len(),
+            start_prod:        rules_prods[usize::from(nonterm_map[&start_nonterm])][0],
+            rules_prods:       rules_prods,
+            prods_rules:       prods_rules,
+            prods:             prods,
+            prod_precs:        prod_precs
+        }
+    }
+
+    /// Return the productions for nonterminal `i` or None if it doesn't exist.
+    pub fn nonterm_to_prods(&self, i: NTIdx) -> Option<&[PIdx]> {
+        self.rules_prods.get(usize::from(i)).map_or(None, |x| Some(x))
+    }
+
+    /// Return the name of nonterminal `i` or None if it doesn't exist.
+    pub fn nonterm_name(&self, i: NTIdx) -> Option<&str> {
+        self.nonterminal_names.get(usize::from(i)).map_or(None, |x| Some(&x))
+    }
+
+    /// Return an iterator which produces (in no particular order) all this grammar's valid NTIdxs.
+    pub fn iter_nonterm_idxs(&self) -> Box<Iterator<Item=NTIdx>> {
+        Box::new((0..self.nonterms_len).map(NTIdx))
+    }
+
+    /// Get the sequence of symbols for production `i` or None if it doesn't exist.
+    pub fn prod(&self, i: PIdx) -> Option<&[Symbol]> {
+        self.prods.get(usize::from(i)).map_or(None, |x| Some(x))
+    }
+
+    /// Return the nonterm index of the production `i` or None if it doesn't exist.
+    pub fn prod_to_nonterm(&self, i: PIdx) -> NTIdx {
+        self.prods_rules[usize::from(i)]
+    }
+
+    /// Return the precedence of production `i` or None if it doesn't exist.
+    pub fn prod_precedence(&self, i: PIdx) -> Option<Option<Precedence>> {
+        self.prod_precs.get(usize::from(i)).map_or(None, |x| Some(*x))
+    }
+
+    /// Return the name of terminal `i` or None if it doesn't exist.
+    pub fn term_name(&self, i: TIdx) -> Option<&str> {
+        self.terminal_names.get(usize::from(i)).map_or(None, |x| Some(x))
+    }
+
+    /// Return the precedence of terminal `i` or None if it doesn't exist.
+    pub fn term_precedence(&self, i: TIdx) -> Option<Option<Precedence>> {
+        self.terminal_precs.get(usize::from(i)).map_or(None, |x| Some(*x))
+    }
+
+    /// Return an iterator which produces (in no particular order) all this grammar's valid TIdxs.
+    pub fn iter_term_idxs(&self) -> Box<Iterator<Item=TIdx>> {
+        Box::new((0..self.terms_len).map(TIdx))
+    }
+}
+
+#[cfg(test)]
+impl YaccGrammar {
+    /// Map a nonterminal name to the corresponding rule offset.
+    pub fn nonterminal_off(&self, n: &str) -> NTIdx {
+        NTIdx(self.nonterminal_names.iter().position(|x| x == n).unwrap())
+    }
+
+    /// Map a terminal name to the corresponding terminal offset.
+    pub fn terminal_off(&self, n: &str) -> TIdx {
+        TIdx(self.terminal_names.iter().position(|x| x == n).unwrap())
+    }
+
+    /// Map a production number to a rule name.
+    pub fn prod_to_term_name(&self, i: PIdx) -> &str {
+        &self.nonterminal_names[usize::from(self.prod_to_nonterm(i))]
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::{AssocKind, YaccGrammar, NTIdx, PIdx, Precedence, Symbol, TIdx};
+    use yacc::parser::parse_yacc;
+
+    #[test]
+    fn test_minimal() {
+        let ast = parse_yacc(&"%start R %token T %% R: 'T';".to_string()).unwrap();
+        let grm = YaccGrammar::new(&ast);
+
+        assert_eq!(grm.start_prod, PIdx(0));
+        grm.nonterminal_off("^");
+        grm.nonterminal_off("R");
+        grm.terminal_off("$");
+        grm.terminal_off("T");
+
+        assert_eq!(grm.rules_prods, vec![vec![PIdx(0)], vec![PIdx(1)]]);
+        let start_prod = grm.prod(grm.rules_prods[usize::from(grm.nonterminal_off("^"))][0]).unwrap();
+        assert_eq!(*start_prod, [Symbol::Nonterminal(grm.nonterminal_off("R"))]);
+        let r_prod = grm.prod(grm.rules_prods[usize::from(grm.nonterminal_off("R"))][0]).unwrap();
+        assert_eq!(*r_prod, [Symbol::Terminal(grm.terminal_off("T"))]);
+        assert_eq!(grm.prods_rules, vec![NTIdx(0), NTIdx(1)]);
+
+        assert_eq!(grm.iter_term_idxs().collect::<Vec<TIdx>>(), vec![TIdx(0), TIdx(1)]);
+        assert_eq!(grm.iter_nonterm_idxs().collect::<Vec<NTIdx>>(), vec![NTIdx(0), NTIdx(1)]);
+    }
+
+    #[test]
+    fn test_rule_ref() {
+        let ast = parse_yacc(&"%start R %token T %% R : S; S: 'T';".to_string()).unwrap();
+        let grm = YaccGrammar::new(&ast);
+
+        grm.nonterminal_off("^");
+        grm.nonterminal_off("R");
+        grm.nonterminal_off("S");
+        grm.terminal_off("$");
+        grm.terminal_off("T");
+
+        assert_eq!(grm.rules_prods, vec![vec![PIdx(0)], vec![PIdx(1)], vec![PIdx(2)]]);
+        let start_prod = grm.prod(grm.rules_prods[usize::from(grm.nonterminal_off("^"))][0]).unwrap();
+        assert_eq!(*start_prod, [Symbol::Nonterminal(grm.nonterminal_off("R"))]);
+        let r_prod = grm.prod(grm.rules_prods[usize::from(grm.nonterminal_off("R"))][0]).unwrap();
+        assert_eq!(r_prod.len(), 1);
+        assert_eq!(r_prod[0], Symbol::Nonterminal(grm.nonterminal_off("S")));
+        let s_prod = grm.prod(grm.rules_prods[usize::from(grm.nonterminal_off("S"))][0]).unwrap();
+        assert_eq!(s_prod.len(), 1);
+        assert_eq!(s_prod[0], Symbol::Terminal(grm.terminal_off("T")));
+    }
+
+    #[test]
+    fn test_long_prod() {
+        let ast = parse_yacc(&"%start R %token T1 T2 %% R : S 'T1' S; S: 'T2';".to_string()).unwrap();
+        let grm = YaccGrammar::new(&ast);
+
+        grm.nonterminal_off("^");
+        grm.nonterminal_off("R");
+        grm.nonterminal_off("S");
+        grm.terminal_off("$");
+        grm.terminal_off("T1");
+        grm.terminal_off("T2");
+
+        assert_eq!(grm.rules_prods, vec![vec![PIdx(0)], vec![PIdx(1)], vec![PIdx(2)]]);
+        assert_eq!(grm.prods_rules, vec![NTIdx(0), NTIdx(1), NTIdx(2)]);
+        let start_prod = grm.prod(grm.rules_prods[usize::from(grm.nonterminal_off("^"))][0]).unwrap();
+        assert_eq!(*start_prod, [Symbol::Nonterminal(grm.nonterminal_off("R"))]);
+        let r_prod = grm.prod(grm.rules_prods[usize::from(grm.nonterminal_off("R"))][0]).unwrap();
+        assert_eq!(r_prod.len(), 3);
+        assert_eq!(r_prod[0], Symbol::Nonterminal(grm.nonterminal_off("S")));
+        assert_eq!(r_prod[1], Symbol::Terminal(grm.terminal_off("T1")));
+        assert_eq!(r_prod[2], Symbol::Nonterminal(grm.nonterminal_off("S")));
+        let s_prod = grm.prod(grm.rules_prods[usize::from(grm.nonterminal_off("S"))][0]).unwrap();
+        assert_eq!(s_prod.len(), 1);
+        assert_eq!(s_prod[0], Symbol::Terminal(grm.terminal_off("T2")));
+    }
+
+
+    #[test]
+    fn test_prods_rules() {
+        let grm = YaccGrammar::new(&parse_yacc(&"
+            %start A
+            %%
+            A: B
+             | C;
+            B: 'x';
+            C: 'y'
+             | 'z';
+          ".to_string()).unwrap());
+
+        assert_eq!(grm.prods_rules, vec![NTIdx(0), NTIdx(1), NTIdx(1), NTIdx(2), NTIdx(3), NTIdx(3)]);
+    }
+
+    #[test]
+    fn test_left_right_nonassoc_precs() {
+        let grm = YaccGrammar::new(&parse_yacc(&"
+            %start Expr
+            %right '='
+            %left '+' '-'
+            %left '/'
+            %left '*'
+            %nonassoc '~'
+            %%
+            Expr : Expr '=' Expr
+                 | Expr '+' Expr
+                 | Expr '-' Expr
+                 | Expr '/' Expr
+                 | Expr '*' Expr
+                 | Expr '~' Expr
+                 | 'id' ;
+          ").unwrap());
+
+        assert_eq!(grm.prod_precs.len(), 8);
+        assert_eq!(grm.prod_precs[0], None);
+        assert_eq!(grm.prod_precs[1].unwrap(), Precedence{level: 0, kind: AssocKind::Right});
+        assert_eq!(grm.prod_precs[2].unwrap(), Precedence{level: 1, kind: AssocKind::Left});
+        assert_eq!(grm.prod_precs[3].unwrap(), Precedence{level: 1, kind: AssocKind::Left});
+        assert_eq!(grm.prod_precs[4].unwrap(), Precedence{level: 2, kind: AssocKind::Left});
+        assert_eq!(grm.prod_precs[5].unwrap(), Precedence{level: 3, kind: AssocKind::Left});
+        assert_eq!(grm.prod_precs[6].unwrap(), Precedence{level: 4, kind: AssocKind::Nonassoc});
+        assert!(grm.prod_precs[7].is_none());
+    }
+
+    #[test]
+    fn test_prec_override() {
+        let grm = YaccGrammar::new(&parse_yacc(&"
+            %start expr
+            %left '+' '-'
+            %left '*' '/'
+            %%
+            expr : expr '+' expr
+                 | expr '-' expr
+                 | expr '*' expr
+                 | expr '/' expr
+                 | '-'  expr %prec '*'
+                 | 'id' ;
+        ").unwrap());
+        assert_eq!(grm.prod_precs.len(), 7);
+        assert_eq!(grm.prod_precs[0], None);
+        assert_eq!(grm.prod_precs[1].unwrap(), Precedence{level: 0, kind: AssocKind::Left});
+        assert_eq!(grm.prod_precs[2].unwrap(), Precedence{level: 0, kind: AssocKind::Left});
+        assert_eq!(grm.prod_precs[3].unwrap(), Precedence{level: 1, kind: AssocKind::Left});
+        assert_eq!(grm.prod_precs[4].unwrap(), Precedence{level: 1, kind: AssocKind::Left});
+        assert_eq!(grm.prod_precs[5].unwrap(), Precedence{level: 1, kind: AssocKind::Left});
+        assert!(grm.prod_precs[6].is_none());
+    }
+}

--- a/src/lib/yacc/parser.rs
+++ b/src/lib/yacc/parser.rs
@@ -1,0 +1,744 @@
+// Copyright (c) 2017 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
+// copy of this software, associated documentation and/or data (collectively the "Software"), free
+// of charge and under any and all copyright rights in the Software, and any and all patent rights
+// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
+// below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software is contributed
+// by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create derivative works
+// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
+// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
+// foregoing rights on either these or other terms.
+//
+// This license is subject to the following condition: The above copyright notice and either this
+// complete permission notice or at a minimum a reference to the UPL must be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+use std::fmt;
+
+extern crate regex;
+use self::regex::Regex;
+
+type YaccResult<T> = Result<T, YaccParserError>;
+
+use yacc::{AssocKind, Precedence};
+use yacc::ast::{GrammarAST, Symbol};
+
+pub struct YaccParser {
+    src: String,
+    newlines: Vec<usize>,
+    grammar: GrammarAST
+}
+
+/// The various different possible Yacc parser errors.
+#[derive(Debug)]
+pub enum YaccParserErrorKind {
+    IllegalName,
+    IllegalString,
+    IncompleteRule,
+    MissingColon,
+    PrematureEnd,
+    ProgramsNotSupported,
+    UnknownDeclaration,
+    DuplicatePrecedence,
+    PrecNotFollowedByTerminal,
+}
+
+/// Any error from the Yacc parser returns an instance of this struct.
+#[derive(Debug)]
+pub struct YaccParserError {
+    pub kind: YaccParserErrorKind,
+    line: usize,
+    col: usize
+}
+
+impl fmt::Display for YaccParserError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let s;
+        match self.kind {
+            YaccParserErrorKind::IllegalName          => s = "Illegal name",
+            YaccParserErrorKind::IllegalString        => s = "Illegal string",
+            YaccParserErrorKind::IncompleteRule       => s = "Incomplete rule",
+            YaccParserErrorKind::MissingColon         => s = "Missing colon",
+            YaccParserErrorKind::PrematureEnd         => s = "File ends prematurely",
+            YaccParserErrorKind::ProgramsNotSupported => s = "Programs not currently supported",
+            YaccParserErrorKind::UnknownDeclaration   => s = "Unknown declaration",
+            YaccParserErrorKind::DuplicatePrecedence  => s = "Token already has a precedence",
+            YaccParserErrorKind::PrecNotFollowedByTerminal => s = "%prec not followed by token name"
+        }
+        write!(f, "{} at line {} column {}", s, self.line, self.col)
+    }
+}
+
+lazy_static! {
+    static ref RE_NAME: Regex = {
+        Regex::new(r"^[a-zA-Z_.][a-zA-Z0-9_.]*").unwrap()
+    };
+    static ref RE_TERMINAL: Regex = {
+        Regex::new("^(?:(\".+?\")|('.+?')|([a-zA-Z_][a-zA-Z_0-9]*))").unwrap()
+    };
+}
+
+/// The actual parser is intended to be entirely opaque from outside users.
+impl YaccParser {
+    fn new(src: String) -> YaccParser {
+        YaccParser {
+            src     : src,
+            newlines: vec![0],
+            grammar : GrammarAST::new()
+        }
+    }
+
+    fn mk_error(&self, k: YaccParserErrorKind, off: usize) -> YaccParserError {
+        let (line, col) = self.off_to_line_col(off);
+        YaccParserError{kind: k, line: line, col: col}
+    }
+
+    fn off_to_line_col(&self, off: usize) -> (usize, usize) {
+        if off == self.src.len() {
+            let line_off = *self.newlines.iter().last().unwrap();
+            return (self.newlines.len(), self.src[line_off..].chars().count() + 1);
+        }
+        let (line_m1, &line_off) = self.newlines.iter()
+                                                .enumerate()
+                                                .rev()
+                                                .find(|&(_, &line_off)| line_off <= off)
+                                                .unwrap();
+        let c_off = self.src[line_off..]
+                        .char_indices()
+                        .position(|(c_off, _)| c_off == off - line_off)
+                        .unwrap();
+        (line_m1 + 1, c_off + 1)
+    }
+
+    fn parse(&mut self) -> YaccResult<usize> {
+        // We pass around an index into the *bytes* of self.src. We guarantee that at all times
+        // this points to the beginning of a UTF-8 character (since multibyte characters exist, not
+        // every byte within the string is also a valid character).
+        let mut i = try!(self.parse_declarations(0));
+        i = try!(self.parse_rules(i));
+        // We don't currently support the programs part of a specification. One day we might...
+        match self.lookahead_is("%%", i) {
+            Some(j) => {
+                if try!(self.parse_ws(j)) == self.src.len() {
+                    Ok(i)
+                } else {
+                    Err(self.mk_error(YaccParserErrorKind::ProgramsNotSupported, i))
+                }
+            }
+            None    => Ok(i)
+        }
+    }
+
+    fn parse_declarations(&mut self, mut i: usize) -> YaccResult<usize> {
+        i = try!(self.parse_ws(i));
+        let mut prec_level  = 0;
+        while i < self.src.len() {
+            if self.lookahead_is("%%", i).is_some() { return Ok(i); }
+            if let Some(j) = self.lookahead_is("%token", i) {
+                i = try!(self.parse_ws(j));
+                while i < self.src.len() {
+                    if self.lookahead_is("%", i).is_some() { break; }
+                    let (j, n) = try!(self.parse_terminal(i));
+                    self.grammar.tokens.insert(n);
+                    i = try!(self.parse_ws(j));
+                }
+            } else if let Some(j) = self.lookahead_is("%start", i) {
+                i = try!(self.parse_ws(j));
+                let (j, n) = try!(self.parse_name(i));
+                self.grammar.start = Some(n);
+                i = try!(self.parse_ws(j));
+            } else {
+                let k;
+                let kind;
+                if let Some(j) = self.lookahead_is("%left", i) {
+                    kind = AssocKind::Left;
+                    k = j;
+                } else if let Some(j) = self.lookahead_is("%right", i) {
+                    kind = AssocKind::Right;
+                    k = j;
+                } else if let Some(j) = self.lookahead_is("%nonassoc", i) {
+                    kind = AssocKind::Nonassoc;
+                    k = j;
+                } else {
+                    return Err(self.mk_error(YaccParserErrorKind::UnknownDeclaration, i));
+                }
+
+                i = try!(self.parse_ws(k));
+                while i < self.src.len() {
+                    if self.lookahead_is("%", i).is_some() { break; }
+                    let (j, n) = try!(self.parse_terminal(i));
+                    if self.grammar.precs.contains_key(&n) {
+                        return Err(self.mk_error(YaccParserErrorKind::DuplicatePrecedence, i));
+                    }
+                    let prec = Precedence{level: prec_level, kind: kind};
+                    self.grammar.precs.insert(n, prec);
+                    i = try!(self.parse_ws(j));
+                }
+                prec_level += 1;
+            }
+        }
+        Err(self.mk_error(YaccParserErrorKind::PrematureEnd, i - 1))
+    }
+
+    fn parse_rules(&mut self, mut i: usize) -> YaccResult<usize> {
+        // self.parse_declarations should have left the input at '%%'
+        match self.lookahead_is("%%", i) {
+            Some(j) => i = j,
+            None    => panic!("Internal error.")
+        }
+        i = try!(self.parse_ws(i));
+        while i < self.src.len() {
+            if self.lookahead_is("%%", i).is_some() { break; }
+            i = try!(self.parse_rule(i));
+            i = try!(self.parse_ws(i));
+        }
+        Ok(i)
+    }
+
+    fn parse_rule(&mut self, mut i: usize) -> YaccResult<usize> {
+        let (j, rn) = try!(self.parse_name(i));
+        i = try!(self.parse_ws(j));
+        match self.lookahead_is(":", i) {
+            Some(j) => i = j,
+            None    => {
+                return Err(self.mk_error(YaccParserErrorKind::MissingColon, i));
+            }
+        }
+        let mut syms = Vec::new();
+        let mut prec = None;
+        i = try!(self.parse_ws(i));
+        while i < self.src.len() {
+            if let Some(j) = self.lookahead_is("|", i) {
+                self.grammar.add_prod(rn.clone(), syms, prec);
+                syms = Vec::new();
+                prec = None;
+                i = try!(self.parse_ws(j));
+                continue;
+            } else if let Some(j) = self.lookahead_is(";", i) {
+                self.grammar.add_prod(rn.clone(), syms, prec);
+                return Ok(j);
+            }
+
+            if self.lookahead_is("\"", i).is_some() || self.lookahead_is("'", i).is_some() {
+                let (j, sym) = try!(self.parse_terminal(i));
+                i = try!(self.parse_ws(j));
+                self.grammar.tokens.insert(sym.clone());
+                syms.push(Symbol::Terminal(sym));
+            } else if let Some(j) = self.lookahead_is("%prec", i) {
+                i = try!(self.parse_ws(j));
+                let (k, sym) = try!(self.parse_terminal(i));
+                if self.grammar.tokens.contains(&sym) {
+                    prec = Some(sym);
+                } else {
+                    return Err(self.mk_error(YaccParserErrorKind::PrecNotFollowedByTerminal, i));
+                }
+                i = k;
+            } else {
+                let (j, sym) = try!(self.parse_terminal(i));
+                if self.grammar.tokens.contains(&sym) {
+                    syms.push(Symbol::Terminal(sym));
+                } else {
+                    syms.push(Symbol::Nonterminal(sym));
+                }
+                i = j;
+            }
+            i = try!(self.parse_ws(i));
+        }
+        Err(self.mk_error(YaccParserErrorKind::IncompleteRule, i))
+    }
+
+    fn parse_name(&self, i: usize) -> YaccResult<(usize, String)> {
+        match RE_NAME.find(&self.src[i..]) {
+            Some((s, e)) => {
+                assert_eq!(s, 0);
+                Ok((i + e, self.src[i..i + e].to_string()))
+            },
+            None         => {
+                Err(self.mk_error(YaccParserErrorKind::IllegalName, i))
+            }
+        }
+    }
+
+    fn parse_terminal(&self, i: usize) -> YaccResult<(usize, String)> {
+        match RE_TERMINAL.find(&self.src[i..]) {
+            Some((s, e)) => {
+                assert!(s == 0 && e > 0);
+                match self.src[i..].chars().next().unwrap() {
+                    '"' | '\'' => {
+                        assert!('"'.len_utf8() == 1 && '\''.len_utf8() == 1);
+                        Ok((i + e, self.src[i + 1..i + e - 1].to_string()))
+                    },
+                    _ =>  Ok((i + e, self.src[i..i + e].to_string()))
+                }
+            },
+            None => {
+                Err(self.mk_error(YaccParserErrorKind::IllegalString, i))
+            }
+        }
+    }
+
+    fn parse_ws(&mut self, i: usize) -> YaccResult<usize> {
+        let mut j = i;
+        for c in self.src[i..].chars() {
+            match c {
+                ' '  | '\t' => (),
+                '\n' | '\r' => self.newlines.push(j + 1),
+                _           => break
+            }
+            j += c.len_utf8();
+        }
+        Ok(j)
+    }
+
+    fn lookahead_is(&self, s: &'static str, i: usize) -> Option<usize> {
+        if self.src[i..].starts_with(s) {
+            Some(i + s.len())
+        } else {
+            None
+        }
+    }
+}
+
+pub fn parse_yacc(s:&str) -> Result<GrammarAST, YaccParserError> {
+    let mut yp = YaccParser::new(s.to_string());
+    match yp.parse() {
+        Ok(_) => Ok(yp.grammar),
+        Err(e) => Err(e)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{parse_yacc, YaccParserError, YaccParserErrorKind};
+    use yacc::{AssocKind, Precedence};
+    use yacc::ast::{Rule, Symbol};
+
+    fn nonterminal(n: &str) -> Symbol {
+        Symbol::Nonterminal(n.to_string())
+    }
+
+    fn terminal(n: &str) -> Symbol {
+        Symbol::Terminal(n.to_string())
+    }
+
+    #[test]
+    fn test_macro() {
+        assert_eq!(Symbol::Terminal("A".to_string()), terminal("A"));
+    }
+
+    #[test]
+    fn test_symbol_eq() {
+        assert_eq!(nonterminal("A"), nonterminal("A"));
+        assert!(nonterminal("A") != nonterminal("B"));
+        assert!(nonterminal("A") != terminal("A"));
+    }
+
+    #[test]
+    fn test_rule_eq() {
+        assert_eq!(Rule::new("A".to_string()), Rule::new("A".to_string()));
+        assert!(Rule::new("A".to_string()) != Rule::new("B".to_string()));
+
+        let mut rule1 = Rule::new("A".to_string());
+        rule1.add_prod(vec![terminal("a")], None);
+        let mut rule2 = Rule::new("A".to_string());
+        rule2.add_prod(vec![terminal("a")], None);
+        assert_eq!(rule1, rule2);
+    }
+
+    #[test]
+    fn test_rule() {
+        let src = "
+            %%
+            A : 'a';
+        ".to_string();
+        let grm = parse_yacc(&src).unwrap();
+        let mut rule1 = Rule::new("A".to_string());
+        rule1.add_prod(vec![terminal("a")], None);
+        assert_eq!(*grm.get_rule("A").unwrap(), rule1);
+        let mut rule2 = Rule::new("B".to_string());
+        rule2.add_prod(vec![terminal("a")], None);
+        assert!(*grm.get_rule("A").unwrap() != rule2);
+    }
+
+    #[test]
+    fn test_rule_production_simple() {
+        let src = "
+            %%
+            A : 'a';
+            A : 'b';
+        ".to_string();
+        let grm = parse_yacc(&src).unwrap();
+        let mut rule1 = Rule::new("A".to_string());
+        rule1.add_prod(vec![terminal("a")], None);
+        rule1.add_prod(vec![terminal("b")], None);
+        assert_eq!(*grm.get_rule("A").unwrap(), rule1);
+        let mut rule2 = Rule::new("B".to_string());
+        rule2.add_prod(vec![terminal("a")], None);
+        assert!(*grm.get_rule("A").unwrap() != rule2);
+    }
+
+    #[test]
+    fn test_rule_empty() {
+        let src = "
+            %%
+            A : ;
+            B : 'b' | ;
+            C : | 'c';
+        ".to_string();
+        let grm = parse_yacc(&src).unwrap();
+
+        let mut rule1 = Rule::new("A".to_string());
+        rule1.add_prod(vec![], None);
+        assert_eq!(*grm.get_rule("A").unwrap(), rule1);
+
+        let mut rule2 = Rule::new("B".to_string());
+        rule2.add_prod(vec![terminal("b")], None);
+        rule2.add_prod(vec![], None);
+        assert_eq!(*grm.get_rule("B").unwrap(), rule2);
+
+        let mut rule3 = Rule::new("C".to_string());
+        rule3.add_prod(vec![], None);
+        rule3.add_prod(vec![terminal("c")], None);
+        assert_eq!(*grm.get_rule("C").unwrap(), rule3);
+    }
+
+    #[test]
+    fn test_rule_alternative() {
+        let src = "
+            %%
+            A : 'a' | 'b';
+        ".to_string();
+        let grm = parse_yacc(&src).unwrap();
+        let mut rule1 = Rule::new("A".to_string());
+        rule1.add_prod(vec![terminal("a")], None);
+        rule1.add_prod(vec![terminal("b")], None);
+        assert_eq!(*grm.get_rule("A").unwrap(), rule1);
+        let mut rule2 = Rule::new("B".to_string());
+        rule2.add_prod(vec![terminal("a")], None);
+        assert!(*grm.get_rule("A").unwrap() != rule2);
+    }
+
+    #[test]
+    fn test_empty_program() {
+        let src = "%%\nA : 'a';\n%%".to_string();
+        parse_yacc(&src).unwrap();
+    }
+
+    #[test]
+    fn test_multiple_symbols() {
+        let src = "%%\nA : 'a' B;".to_string();
+        let grm = parse_yacc(&src).unwrap();
+        let mut rule = Rule::new("A".to_string());
+        rule.add_prod(vec![terminal("a"), nonterminal("B")], None);
+        assert_eq!(*grm.get_rule("A").unwrap(), rule)
+    }
+
+    #[test]
+    fn test_token_types() {
+        let src = "%%\nA : 'a' \"b\";".to_string();
+        let grm = parse_yacc(&src).unwrap();
+        let mut rule = Rule::new("A".to_string());
+        rule.add_prod(vec![terminal("a"), terminal("b")], None);
+        assert_eq!(*grm.get_rule("A").unwrap(), rule)
+    }
+
+    #[test]
+    fn test_declaration_start() {
+        let src = "%start   A\n%%\nA : a;".to_string();
+        let grm = parse_yacc(&src).unwrap();
+        assert_eq!(grm.start.unwrap(), "A");
+    }
+
+    #[test]
+    fn test_declaration_token() {
+        let src = "%token   a\n%%\nA : a;".to_string();
+        let grm = parse_yacc(&src).unwrap();
+        assert!(grm.has_token("a"));
+    }
+
+    #[test]
+    fn test_declaration_token_literal() {
+        let src = "%token   'a'\n%%\nA : 'a';".to_string();
+        let grm = parse_yacc(&src).unwrap();
+        assert!(grm.has_token("a"));
+    }
+
+    #[test]
+    fn test_declaration_tokens() {
+        let src = "%token   a b c 'd'\n%%\nA : a;".to_string();
+        let grm = parse_yacc(&src).unwrap();
+        assert!(grm.has_token("a"));
+        assert!(grm.has_token("b"));
+        assert!(grm.has_token("c"));
+    }
+
+    #[test]
+    fn test_auto_add_tokens() {
+        let src = "%%\nA : 'a';".to_string();
+        let grm = parse_yacc(&src).unwrap();
+        assert!(grm.has_token("a"));
+    }
+
+    #[test]
+    fn test_token_non_literal() {
+        let src = "%token T %%\nA : T;".to_string();
+        let grm = parse_yacc(&src).unwrap();
+        assert!(grm.has_token("T"));
+        match grm.rules["A"].productions[0].symbols[0] {
+            Symbol::Nonterminal(_) => panic!("Should be terminal"),
+            Symbol::Terminal(_)    => ()
+        }
+    }
+
+    #[test]
+    fn test_token_unicode() {
+        let src = "%token '❤' %%\nA : '❤';".to_string();
+        let grm = parse_yacc(&src).unwrap();
+        assert!(grm.has_token("❤"));
+    }
+
+    #[test]
+    fn test_unicode_err1() {
+        let src = "%token '❤' ❤;".to_string();
+        match parse_yacc(&src) {
+            Ok(_)  => panic!("Incorrect token parsed"),
+            Err(YaccParserError{kind: YaccParserErrorKind::IllegalString, line: 1, col: 12}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    fn test_unicode_err2() {
+        let src = "%token '❤'\n%%\nA : '❤' | ❤;".to_string();
+        match parse_yacc(&src) {
+            Ok(_)  => panic!("Incorrect token parsed"),
+            Err(YaccParserError{kind: YaccParserErrorKind::IllegalString, line: 3, col: 11}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_simple_decl_fail() {
+        let src = "%fail x\n%%\nA : a".to_string();
+        parse_yacc(&src).unwrap();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_empty() {
+        let src = "".to_string();
+        parse_yacc(&src).unwrap();
+    }
+
+    #[test]
+    fn test_incomplete_rule1() {
+        let src = "%%A:".to_string();
+        match parse_yacc(&src) {
+            Ok(_)  => panic!("Incomplete rule parsed"),
+            Err(YaccParserError{kind: YaccParserErrorKind::IncompleteRule, line: 1, col: 5}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    fn test_line_col_report1() {
+        let src = "%%
+A:".to_string();
+        match parse_yacc(&src) {
+            Ok(_)  => panic!("Incomplete rule parsed"),
+            Err(YaccParserError{kind: YaccParserErrorKind::IncompleteRule, line: 2, col: 3}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    fn test_line_col_report2() {
+        let src = "%%
+A:
+".to_string();
+        match parse_yacc(&src) {
+            Ok(_)  => panic!("Incomplete rule parsed"),
+            Err(YaccParserError{kind: YaccParserErrorKind::IncompleteRule, line: 3, col: 1}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    fn test_line_col_report3() {
+        let src = "
+
+        %woo".to_string();
+        match parse_yacc(&src) {
+            Ok(_)  => panic!("Incomplete rule parsed"),
+            Err(YaccParserError{kind: YaccParserErrorKind::UnknownDeclaration, line: 3, col: 9}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    fn test_missing_colon() {
+        let src = "%%A x;".to_string();
+        match parse_yacc(&src) {
+            Ok(_)  => panic!("Missing colon parsed"),
+            Err(YaccParserError{kind: YaccParserErrorKind::MissingColon, line: 1, col: 5}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    fn test_premature_end() {
+        let src = "%token x".to_string();
+        match parse_yacc(&src) {
+            Ok(_)  => panic!("Incomplete rule parsed"),
+            Err(YaccParserError{kind: YaccParserErrorKind::PrematureEnd, line: 1, col: 8}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    fn test_programs_not_supported() {
+        let src = "%% %%
+x".to_string();
+        match parse_yacc(&src) {
+            Ok(_)  => panic!("Programs parsed"),
+            Err(YaccParserError{kind: YaccParserErrorKind::ProgramsNotSupported, line: 1, col: 4}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    fn test_unknown_declaration() {
+        let src = "%woo".to_string();
+        match parse_yacc(&src) {
+            Ok(_)  => panic!("Unknown declaration parsed"),
+            Err(YaccParserError{kind: YaccParserErrorKind::UnknownDeclaration, line: 1, col: 1}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    fn test_precs() {
+        let src = "
+          %left '+' '-'
+          %left '*'
+          %right '/'
+          %right '^'
+          %nonassoc '~'
+          %%
+          ".to_string();
+        let grm = parse_yacc(&src).unwrap();
+        assert_eq!(grm.precs.len(), 6);
+        assert_eq!(grm.precs["+"], Precedence{level: 0, kind: AssocKind::Left});
+        assert_eq!(grm.precs["-"], Precedence{level: 0, kind: AssocKind::Left});
+        assert_eq!(grm.precs["*"], Precedence{level: 1, kind: AssocKind::Left});
+        assert_eq!(grm.precs["/"], Precedence{level: 2, kind: AssocKind::Right});
+        assert_eq!(grm.precs["^"], Precedence{level: 3, kind: AssocKind::Right});
+        assert_eq!(grm.precs["~"], Precedence{level: 4, kind: AssocKind::Nonassoc});
+    }
+
+    #[test]
+    fn test_dup_precs() {
+        let srcs = vec![
+          "
+          %left 'x'
+          %left 'x'
+          %%
+          ",
+          "
+          %left 'x'
+          %right 'x'
+          %%
+          ",
+          "
+          %right 'x'
+          %right 'x'
+          %%
+          ",
+          "
+          %nonassoc 'x'
+          %nonassoc 'x'
+          %%
+          ",
+          "
+          %left 'x'
+          %nonassoc 'x'
+          %%
+          ",
+          "
+          %right 'x'
+          %nonassoc 'x'
+          %%
+          "
+          ];
+        for src in srcs.iter() {
+            match parse_yacc(&src.to_string()) {
+                Ok(_) => panic!("Duplicate precedence parsed"),
+                Err(YaccParserError{kind: YaccParserErrorKind::DuplicatePrecedence, line: 3, ..}) => (),
+                Err(e) => panic!("Incorrect error returned {}", e)
+            }
+        }
+    }
+
+    #[test]
+    fn test_prec_override() {
+        // Taken from the Yacc manual
+        let src = "
+            %left '+' '-'
+            %left '*' '/'
+            %%
+            expr : expr '+' expr
+                 | expr '-' expr
+                 | expr '*' expr
+                 | expr '/' expr
+                 | '-'  expr %prec '*'
+                 | NAME ;
+        ";
+        let grm = parse_yacc(&src).unwrap();
+        assert_eq!(grm.precs.len(), 4);
+        println!("{:?}", grm.rules);
+        assert_eq!(grm.rules["expr"].productions[0].precedence, None);
+        assert_eq!(grm.rules["expr"].productions[3].symbols.len(), 3);
+        assert_eq!(grm.rules["expr"].productions[4].symbols.len(), 2);
+        assert_eq!(grm.rules["expr"].productions[4].precedence, Some("*".to_string()));
+    }
+
+    #[test]
+    fn test_bad_prec_overrides() {
+        match parse_yacc(&"
+          %%
+          S: 'A' %prec ;
+          ") {
+                Ok(_) => panic!("Incorrect %prec parsed"),
+                Err(YaccParserError{kind: YaccParserErrorKind::IllegalString, line: 3, ..}) => (),
+                Err(e) => panic!("Incorrect error returned {}", e)
+        }
+
+        match parse_yacc(&"
+          %%
+          S: 'A' %prec B;
+          B: ;
+          ") {
+                Ok(_) => panic!("Incorrect %prec parsed"),
+                Err(YaccParserError{kind: YaccParserErrorKind::PrecNotFollowedByTerminal, line: 3, ..}) => (),
+                Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+}


### PR DESCRIPTION
This library is intended, ultimately, to be able to represent various types of Context-Free Grammars (CFGs) in Rust. It has a `Grammar` trait which is intended to capture those factors common to all grammars. Individual CFG variants can then add extra features as they need.

Currently I've ripped out the Yacc-ish parts from the `lrtable` library, so that this library can at least represent those. This stuff never made much sense in `lrtable`, but our medium-term plans would have completely broken the model, so putting them in a separate library makes more sense IMHO. This will give us a half-sensible means of treating different grammars as e.g. "pure Yacc grammar" or "Eco variant" (e.g. automatically adding whitespace), whilst not unduly interfering with lrtable.

Since this PR appears to be all new code (no diffing between repos, I'm afraid!), it's a little hard to see what's gone on. Yacc parsing and grammar representation code has been moved from `lrtable`; what was called `Grammar` is now called `YaccGrammar`. A new trait `Grammar` has been added (see above). There's probably more stuff that should be moved from `YaccGrammar` to `Grammar`, but I think that's best done as a separate PR.

I suggest looking at each commit in isolation rather than the whole PR.