### PR TITLE
Move and extend API

### DIFF
--- a/src/lib/yacc/mod.rs
+++ b/src/lib/yacc/mod.rs
@@ -309,10 +309,18 @@ impl From<GrammarValidationError> for YaccGrammarError {
     }
 }
 
-pub fn yacc_grm(s: &str) -> Result<YaccGrammar, YaccGrammarError> {
-    let ast = try!(parser::yacc_ast(s));
-    try!(ast.validate());
-    Ok(YaccGrammar::new(&ast))
+pub enum YaccKind {
+    Original
+}
+
+pub fn yacc_grm(yacc_kind: YaccKind, s: &str) -> Result<YaccGrammar, YaccGrammarError> {
+    match yacc_kind {
+        YaccKind::Original => {
+            let ast = try!(parser::yacc_ast(s));
+            try!(ast.validate());
+            Ok(YaccGrammar::new(&ast))
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This is the first in a sequence of PRs for effected repos (including rstreediff).

It does two things which in one sense should be separate PRs, but that would require two lots of this tedious "change all repos at the same time" dance. So I'm squeezing them together:

  1) Move the ability to create yacc grammars from lrtable to cfgrammar. This should have happened in the original port, but I somehow failed to notice it. As a bonus, this noticeably simplifies the API at the same time. 
  2) Add an ability to say *which* Yacc variant we want parsed. At the moment we only handle classic/original Yacc grammars, but in the future we could handle e.g. Eco-ish grammars.

I suggest it's better to review the two commits here separately, as they're not really related.

Once we've merged this, I'll make PRs for the other repos. Ah, if only GitHub allowed me to sequence them somehow...