### PR TITLE
Allow users to find out the maximum cost of a non-terminal

### DIFF
--- a/src/lib/yacc/grammar.rs
+++ b/src/lib/yacc/grammar.rs
@@ -656,7 +656,10 @@ fn nonterm_costs<F>(grm: &YaccGrammar, term_cost: F) -> Vec<u64>
     done.resize(grm.nonterms_len(), false);
     loop {
         let mut all_done = true;
-        for (i, _) in done.clone().iter().enumerate().filter(|&(_, d)| !d) {
+        for i in 0..done.len() {
+            if done[i] {
+                continue;
+            }
             all_done = false;
             let mut ls_cmplt = None; // lowest completed cost
             let mut ls_noncmplt = None; // lowest non-completed cost

--- a/src/lib/yacc/grammar.rs
+++ b/src/lib/yacc/grammar.rs
@@ -506,7 +506,7 @@ impl<'a> SentenceGenerator<'a> {
                 let mut sc = 0;
                 for sym in self.grm.prod(pidx).iter() {
                     sc += match *sym {
-                        Symbol::Nonterm(i) => self.nonterm_min_costs[usize::from(i)],
+                        Symbol::Nonterm(i) => self.min_sentence_cost(i),
                         Symbol::Term(i)    => self.term_costs[usize::from(i)]
                     };
                 }
@@ -547,7 +547,7 @@ impl<'a> SentenceGenerator<'a> {
                 let mut sc = 0;
                 for sym in self.grm.prod(pidx).iter() {
                     sc += match *sym {
-                        Symbol::Nonterm(i) => self.nonterm_min_costs[usize::from(i)],
+                        Symbol::Nonterm(i) => self.min_sentence_cost(i),
                         Symbol::Term(i)    => self.term_costs[usize::from(i)]
                     };
                 }


### PR DESCRIPTION
For this grammar:

```
    %start A
    %%
    A: A B | B;
    B: C | D;
    C: 'x' 'y' | 'x';
    D: 'y' 'x' | 'y' 'x' 'z';
```

the costs of a maximum length sentence are as follows:

* A: infinite
* B: 3
* C: 2
* D: 3

This PR adds the ability to find out those costs. This requires a different API from minimum costs, because of the "infinite" case.

The main commit is https://github.com/softdevteam/cfgrammar/commit/ec71351d44c24d8c8df497a7185e721bed83d19b -- the other commits either do bits of refactoring, or make things a bit more efficient for users who only want to generate min or max sentences but not both (https://github.com/softdevteam/cfgrammar/commit/59797aa4d6569edfcf298b365484cd45739b4be8).