### PR TITLE
u32 types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: rust
-rust: stable
+rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,7 @@ name = "cfgrammar"
 path = "src/lib/mod.rs"
 
 [dependencies]
-getopts = "0.2.15"
+getopts = "0.2.17"
 lazy_static = "0.2.8"
 regex = "0.2.2"
-macro-attr = "0.2.0"
-newtype_derive = "0.1.6"
 linked-hash-map = "0.5.0"

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -30,6 +30,40 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+//! A library for manipulating Context Free Grammars (CFG). At the moment it only really supports
+//! Yacc-style grammars (albeit several variants of Yacc grammars), but the long-term aim is to
+//! provide an API that, when possible, is agnostic about the type of grammar being manipulated.
+//!
+//! A note on the terminology we use, since there's no universal standard (and EBNF, which is
+//! perhaps the closest we've got, uses terminology that now seems partially anachronistic):
+//!
+//!   * A rule is a mapping from a nonterminal name to 1 or more productions (the latter of which
+//!     is often called 'alternatives').
+//!   * A symbol is either a nonterminal or a terminal.
+//!   * A production is a (possibly empty) ordered sequence of symbols.
+//!
+//! Every nonterminal has a corresponding rule (and thus the two concepts are interchangeable);
+//! however, terminals are not required to appear in any production (such terminals can be used to
+//! catch error conditions).
+//!
+//! We make the following guarantees about grammars:
+//!
+//!   * The grammar has a single start rule accessed by `start_rule_idx`.
+//!   * The non-terminals are numbered from `0` to `nonterms_len() - 1` (inclusive).
+//!   * The productions are numbered from `0` to `prods_len() - 1` (inclusive).
+//!   * The terminals are numbered from `0` to `terms_len() - 1` (inclusive).
+//!
+//! This means that it is safe to write code such as:
+//!
+//! ```text
+//! for i in 0..grm.nonterms_len() as usize {
+//!   println!("{}", grm.nonterm_name(NTIdx::from(i)));
+//! }
+//! ```
+//!
+//! For most current uses, the main function to investigate is [`yacc_grm`](yacc/fn.yacc_grm.html)
+//! which takes as input a Yacc grammar.
+
 #![feature(try_from)]
 
 #[macro_use] extern crate lazy_static;
@@ -38,20 +72,9 @@ extern crate linked_hash_map;
 mod u32struct;
 pub mod yacc;
 
-// A note on the terminology we use, since there's no universal standard (and EBNF, which is
-// perhaps the closest we've got, uses terminology that now seems partially anachronistic):
-//   A rule is a mapping from a nonterminal name to 1 or more productions (the latter of which is
-//     often called 'alternatives').
-//   A symbol is either a nonterminal or a terminal.
-//   A production is a (possibly empty) ordered sequence of symbols.
-//
-// Every nonterminal has a corresponding rule; however, terminals are not required to appear in any
-// production (such terminals can be used to catch error conditions).
-//
-// Internally, we assume that a grammar's start rule has a single production. Since we manually
-// create the start rule ourselves (without relying on user input), this is a safe assumption.
-
-pub use u32struct::{NTIdx, PIdx, SIdx, TIdx};
+/// A type specifically for nonterminal indices.
+pub use u32struct::NTIdx;
+pub use u32struct::{PIdx, SIdx, TIdx};
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub enum Symbol {

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -30,6 +30,8 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+#![feature(try_from)]
+
 #[macro_use] extern crate lazy_static;
 extern crate linked_hash_map;
 
@@ -59,11 +61,11 @@ pub enum Symbol {
 
 pub trait Grammar {
     /// How many terminals does this grammar have?
-    fn terms_len(&self) -> usize;
+    fn terms_len(&self) -> u32;
     /// How many productions does this grammar have?
-    fn prods_len(&self) -> usize;
+    fn prods_len(&self) -> u32;
     /// How many nonterminals does this grammar have?
-    fn nonterms_len(&self) -> usize;
+    fn nonterms_len(&self) -> u32;
     /// What is the index of the start rule?
     fn start_rule_idx(&self) -> NTIdx;
 }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -31,10 +31,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #[macro_use] extern crate lazy_static;
-#[macro_use] extern crate macro_attr;
-#[macro_use] extern crate newtype_derive;
 extern crate linked_hash_map;
 
+mod u32struct;
 pub mod yacc;
 
 // A note on the terminology we use, since there's no universal standard (and EBNF, which is
@@ -50,27 +49,7 @@ pub mod yacc;
 // Internally, we assume that a grammar's start rule has a single production. Since we manually
 // create the start rule ourselves (without relying on user input), this is a safe assumption.
 
-macro_attr! {
-    /// A type specifically for nonterminal indices.
-    #[derive(Clone, Copy, Debug, Eq, Hash, NewtypeFrom!, PartialEq)]
-    pub struct NTIdx(usize);
-}
-macro_attr! {
-    /// A type specifically for production indices (e.g. a rule "E::=A|B" would
-    /// have two productions for the single rule E).
-    #[derive(Clone, Copy, Debug, Eq, Hash, NewtypeFrom!, PartialEq, PartialOrd)]
-    pub struct PIdx(usize);
-}
-macro_attr! {
-    /// A type specifically for symbol indices (within a production).
-    #[derive(Clone, Copy, Debug, Eq, Hash, NewtypeFrom!, PartialEq, PartialOrd)]
-    pub struct SIdx(usize);
-}
-macro_attr! {
-    /// A type specifically for token indices.
-    #[derive(Clone, Copy, Debug, Eq, Hash, NewtypeFrom!, PartialEq)]
-    pub struct TIdx(usize);
-}
+pub use u32struct::{NTIdx, PIdx, SIdx, TIdx};
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub enum Symbol {

--- a/src/lib/u32struct.rs
+++ b/src/lib/u32struct.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2018 King's College London
+// created by the Software Development Team <http://soft-dev.org/>
+//
+// The Universal Permissive License (UPL), Version 1.0
+//
+// Subject to the condition set forth below, permission is hereby granted to any person obtaining a
+// copy of this software, associated documentation and/or data (collectively the "Software"), free
+// of charge and under any and all copyright rights in the Software, and any and all patent rights
+// owned or freely licensable by each licensor hereunder covering either (i) the unmodified
+// Software as contributed to or provided by such licensor, or (ii) the Larger Works (as defined
+// below), to deal in both
+//
+// (a) the Software, and
+// (b) any piece of software and/or hardware listed in the lrgrwrks.txt file
+// if one is included with the Software (each a "Larger Work" to which the Software is contributed
+// by such licensors),
+//
+// without restriction, including without limitation the rights to copy, create derivative works
+// of, display, perform, and distribute the Software and make, use, sell, offer for sale, import,
+// export, have made, and have sold the Software and the Larger Work(s), and to sublicense the
+// foregoing rights on either these or other terms.
+//
+// This license is subject to the following condition: The above copyright notice and either this
+// complete permission notice or at a minimum a reference to the UPL must be included in all copies
+// or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// This macro generates a struct which exposes a u32 API (but which may, internally, use a smaller
+// storage size).
+
+macro_rules! u32struct {
+    ($(#[$attr:meta])* $n: ident, $t: ident) => {
+        $(#[$attr])*
+        #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd)]
+        pub struct $n {
+            v: $t
+        }
+
+        impl From<u32> for $n {
+            fn from(v: u32) -> Self {
+                if v > $t::max_value() as u32 {
+                    panic!("Overflow");
+                }
+                $n{v: v as $t}
+            }
+        }
+
+        impl From<usize> for $n {
+            fn from(v: usize) -> Self {
+                if v > $t::max_value() as usize {
+                    panic!("Overflow");
+                }
+                $n{v: v as $t}
+            }
+        }
+
+        impl From<$n> for usize {
+            fn from(st: $n) -> Self {
+                st.v as usize
+            }
+        }
+
+        impl From<$n> for u32 {
+            fn from(st: $n) -> Self {
+                st.v as u32
+            }
+        }
+    }
+}
+
+// Will anyone create a grammar with more than 65535 non-terminals, productions, symbols within a
+// production, or terminals? Yes, now that I've said it out loud, they probably will. But all
+// practical grammars I know of are comfortably within these limits, so use narrow storage types
+// for now, knowing that we can transparently move the storage type from u16 to u32 in the future
+// without changing the user visible API.
+
+u32struct!(
+    /// A type specifically for nonterminal indices.
+    NTIdx,
+    u16);
+u32struct!(
+    /// A type specifically for production indices (e.g. a rule `E::=A|B` would
+    /// have two productions for the single rule `E`).
+    PIdx,
+    u16);
+u32struct!(
+    /// A type specifically for symbol indices (within a production).
+    SIdx,
+    u16);
+u32struct!(
+    /// A type specifically for token indices.
+    TIdx,
+    u16);

--- a/src/lib/yacc/grammar.rs
+++ b/src/lib/yacc/grammar.rs
@@ -60,9 +60,8 @@ pub enum AssocKind {
     Nonassoc
 }
 
-/// Representation of a `YaccGrammar`. This struct makes one important guarantee: all of its
-/// terminals will be consecutively, monotonically numbered from `0 .. terms_len()`. In other words,
-/// if this struct has 3 terminals, they are guaranteed to have `TIDx`s of 0, 1, and 2.
+/// Representation of a `YaccGrammar`. See the [top-level documentation](../../index.html) for the
+/// guarantees this struct makes about nonterminals, terminals, productions, and symbols.
 pub struct YaccGrammar {
     /// How many nonterminals does this grammar have?
     nonterms_len: u32,
@@ -96,12 +95,15 @@ pub struct YaccGrammar {
     implicit_nonterm: Option<NTIdx>
 }
 
+// Internally, we assume that a grammar's start rule has a single production. Since we manually
+// create the start rule ourselves (without relying on user input), this is a safe assumption.
+
 impl YaccGrammar {
     /// Translate a `GrammarAST` into a `YaccGrammar`. This function is akin to the part a traditional
     /// compiler that takes in an AST and converts it into a binary.
     ///
     /// As we're compiling the `GrammarAST` into a `Grammar` we add a new start rule (which we'll
-    /// refer to as "^", though the actual name is a fresh name that is guaranteed to be unique)
+    /// refer to as `^`, though the actual name is a fresh name that is guaranteed to be unique)
     /// that references the user defined start rule.
     pub fn new(yacc_kind: YaccKind, ast: &ast::GrammarAST) -> YaccGrammar {
         let mut nonterm_names: Vec<String> = Vec::with_capacity(ast.rules.len() + 1);

--- a/src/lib/yacc/mod.rs
+++ b/src/lib/yacc/mod.rs
@@ -38,12 +38,19 @@ pub use self::parser::{YaccParserError, YaccParserErrorKind};
 use self::parser::YaccParser;
 pub use self::grammar::{AssocKind, Precedence, SentenceGenerator, YaccGrammar, YaccGrammarError};
 
+/// The particular Yacc variant this grammar makes use of.
 #[derive(Clone, Copy)]
 pub enum YaccKind {
+    /// The original Yacc style as documented by
+    /// [Johnson](http://dinosaur.compilertools.net/yacc/index.html)
     Original,
+    /// The variant used in the [Eco language composition editor](http://soft-dev.org/src/eco/)
     Eco
 }
 
+/// Takes as input a Yacc grammar of [`YaccKind`](enum.YaccKind.html) as a `String` `s` and returns a
+/// [`YaccGrammar`](grammar/struct.YaccGrammar.html) (or
+/// ([`YaccGrammarError`](grammar/enum.YaccGrammarError.html) on error).
 pub fn yacc_grm(yacc_kind: YaccKind, s: &str) -> Result<YaccGrammar, YaccGrammarError> {
     match yacc_kind {
         YaccKind::Original | YaccKind::Eco => {


### PR DESCRIPTION
[Please look at https://github.com/softdevteam/lrpar/pull/44 before this PR!]

Make NTIdx and friends have a `u32`-seeming API.

The usize based API was never a very sensible choice for these types: why would the number of non-terminals we can deal with change from 32 bit to 64 bit to 128 bit machines? `u32` is a suitably huge type to capture the number of non-terminals, terminals, productions, and symbols within a production any grammar is ever likely to see. This commit gives all the new types a `u32` based API.

Practically speaking, `u32` is complete overkill for any grammar I've ever come across, none of which comes remotely close to needing this much storage. In fact, every grammar I've seen will happily fit in a `u16`, so using `u32`s just wastes memory. So we cheat and, while presenting an API to the outside world which suggests the new types store `u32`s, we actually store `u16`s internally. If we one day come across a grammar which can't fit inside `u16`, we can change the storage type without changing the new types (i.e. no user of cfgrammar will have to change their code).

The first commit makes the above changes and, aside from the new newtypes themselves, is mostly mechanical; the second deals with minor knock-on effects (but which are separate enough that I thought it worth separating them out) and is almost entirely mechanical; and the third commit is somewhat-random documentation fixes.