### PR TITLE
Update dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: rust
-rust: nightly-2018-03-25
+rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "cfgrammar"
 path = "src/lib/mod.rs"
 
 [dependencies]
-getopts = "0.2.17"
-lazy_static = "0.2.8"
-regex = "0.2.2"
-indexmap = "0.4.1"
+getopts = "0.2"
+lazy_static = "1.0"
+regex = "1.0"
+indexmap = "1.0"


### PR DESCRIPTION
Also make them more generic: there's no compelling reason to specify a patch version, so only specify the major and minor parts of the version number.