### PR TITLE
Basic Serde support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
 language: rust
 rust: nightly
+env:
+    - FEATURES=""
+    - FEATURES="serde"
+script:
+    - cargo build --tests --features "$FEATURES"
+    - cargo test --features "$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ getopts = "0.2"
 lazy_static = "1.0"
 regex = "1.0"
 indexmap = "1.0"
+serde = { version="1.0", features=["derive"], optional=true }

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -68,6 +68,9 @@
 
 #[macro_use] extern crate lazy_static;
 extern crate indexmap;
+#[cfg(feature="serde")]
+#[macro_use]
+extern crate serde;
 
 mod u32struct;
 pub mod yacc;
@@ -77,6 +80,7 @@ pub use u32struct::NTIdx;
 pub use u32struct::{PIdx, SIdx, TIdx};
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Symbol {
     Nonterm(NTIdx),
     Term(TIdx)

--- a/src/lib/u32struct.rs
+++ b/src/lib/u32struct.rs
@@ -37,6 +37,7 @@ macro_rules! u32struct {
     ($(#[$attr:meta])* $n: ident, $t: ident) => {
         $(#[$attr])*
         #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+        #[cfg_attr(feature="serde", derive(Serialize, Deserialize))]
         pub struct $n {
             v: $t
         }

--- a/src/lib/yacc/grammar.rs
+++ b/src/lib/yacc/grammar.rs
@@ -48,12 +48,14 @@ use yacc::parser::YaccParserError;
 
 pub type PrecedenceLevel = u64;
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Precedence {
     pub level: PrecedenceLevel,
     pub kind:  AssocKind
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum AssocKind {
     Left,
     Right,
@@ -62,6 +64,7 @@ pub enum AssocKind {
 
 /// Representation of a `YaccGrammar`. See the [top-level documentation](../../index.html) for the
 /// guarantees this struct makes about nonterminals, terminals, productions, and symbols.
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct YaccGrammar {
     /// How many nonterminals does this grammar have?
     nonterms_len: u32,


### PR DESCRIPTION
Serde is a serialization framework that we're likely to use in the near future for other purposes, but it's a useful thing to support anyway. This is an optional feature, as not all users will want to pay the associated costs.